### PR TITLE
Check for invalid date which can be fixed automaticaly. For example 31st Feb

### DIFF
--- a/src/Normalizer/DateNormalizer.php
+++ b/src/Normalizer/DateNormalizer.php
@@ -37,6 +37,10 @@ class DateNormalizer extends BaseDenormalizer implements NormalizerInterface
         if ($date === false) {
             throw new InvalidDataException('Provided date format is invalid');
         }
+        $dateErrors = date_get_last_errors();
+        if ($dateErrors['warning_count'] > 0 || $dateErrors['error_count'] > 0) {
+            throw new InvalidDataException('The parsed date was invalid');
+        }
         $date->setTimezone($this->getLocalTimezone());
 
         return $date;

--- a/tests/Normalizer/DateNormalizerTest.php
+++ b/tests/Normalizer/DateNormalizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Paysera\Component\Serializer\Tests\Filter;
 
+use Paysera\Component\Serializer\Exception\InvalidDataException;
 use Paysera\Component\Serializer\Normalizer\DateNormalizer;
 
 class DateNormalizerTest extends \PHPUnit_Framework_TestCase
@@ -55,4 +56,12 @@ class DateNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($result);
     }
 
+    public function testMapToEntity_invalid_date_throws_exception()
+    {
+        $service = new DateNormalizer('Y-m-d H:i:s', new \DateTimeZone('Etc/GMT+0'));
+
+        $datetime = null;
+        $this->setExpectedException(InvalidDataException::class);
+        $service->mapToEntity('2013-02-31 12:00:00');
+    }
 }


### PR DESCRIPTION
Check for invalid date which can be fixed automaticaly. For example 31st Feb. Current behaviour would set it to 3rd May or 2nd May depending if it is a leap-year or not.