### PR TITLE
Remove implicitly nullable parameter declarations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: flex
 
+      - name: Ignore specific Composer audit advisory
+        run: |
+            if [[ "${{ matrix.php }}" == "7.1" ]]; then
+                echo "COMPOSER_AUDIT_BLOCK_INSECURE=0" >> $GITHUB_ENV
+            else
+                composer config --global audit.ignore "PKSA-w2tw-kmfg-rt9s"
+            fi
+
       - name: Install dependencies
         uses: ramsey/composer-install@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
         symfony:
           - '3.*'
           - '4.*'
@@ -38,6 +40,8 @@ jobs:
           - { php: '8.0', symfony: '3.*' }
           - { php: '8.1', symfony: '3.*' }
           - { php: '8.2', symfony: '3.*' }
+          - { php: '8.3', symfony: '3.*' }
+          - { php: '8.4', symfony: '3.*' }
           - { php: '7.1', symfony: '5.*' }
           - { php: '7.1', symfony: '6.*' }
           - { php: '7.2', symfony: '6.*' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.0
+### Added
+- PHP 8.4 support, removed implicitly nullable parameter declarations.
+
 ## 3.3.0
 ### Added
 - Symfony 6 support.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "paysera/lib-serializer",
     "description": "Library can (de)serialize various data types",
-    "version": "3.4.0",
     "autoload": {
         "psr-4": {
             "Paysera\\Component\\Serializer\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "paysera/lib-serializer",
     "description": "Library can (de)serialize various data types",
+    "version": "3.4.0",
     "autoload": {
         "psr-4": {
             "Paysera\\Component\\Serializer\\": "src/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -10,20 +11,19 @@
          stopOnFailure="false"
          bootstrap="vendor/autoload.php">
 
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+
     <testsuites>
         <testsuite name="Evp Serializer Component Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
 </phpunit>

--- a/src/Entity/Result.php
+++ b/src/Entity/Result.php
@@ -40,7 +40,7 @@ class Result implements \IteratorAggregate, ResultInterface
     protected $items;
 
 
-    public function __construct(Filter $filter = null)
+    public function __construct(?Filter $filter = null)
     {
         $this->filter = $filter;
     }

--- a/src/Exception/InvalidDataException.php
+++ b/src/Exception/InvalidDataException.php
@@ -22,7 +22,7 @@ class InvalidDataException extends Exception
      */
     private $violations;
 
-    public function __construct($message = '', $customCode = null, \Exception $previous = null)
+    public function __construct($message = '', $customCode = null, ?Exception $previous = null)
     {
         $this->customCode = $customCode;
         $this->violations = [];

--- a/src/Filter/FieldsFilter.php
+++ b/src/Filter/FieldsFilter.php
@@ -17,12 +17,12 @@ class FieldsFilter
 
     /**
      * @param array $data
-     * @param array $fields
+     * @param null|array $fields
      * @param array $scope
      *
      * @return array
      */
-    public function filter($data, array $fields = null, array $scope = array())
+    public function filter($data, ?array $fields = null, array $scope = [])
     {
         $fieldsConfig = $this->fieldsParser->parseFields($fields, $scope);
 

--- a/src/Filter/FieldsParser.php
+++ b/src/Filter/FieldsParser.php
@@ -6,12 +6,12 @@ class FieldsParser
 {
 
     /**
-     * @param array $fields
+     * @param null|array $fields
      * @param array $scope
      *
      * @return FieldsConfig
      */
-    public function parseFields(array $fields = null, array $scope = array())
+    public function parseFields(?array $fields = null, array $scope = [])
     {
         $fieldsConfig = $this->parseUnscopedFields($fields);
         foreach ($scope as $fieldName) {
@@ -21,12 +21,12 @@ class FieldsParser
     }
 
     /**
-     * @param array $fields
+     * @param null|array $fields
      *
      * @throws \InvalidArgumentException
      * @return FieldsConfig
      */
-    public function parseUnscopedFields(array $fields = null)
+    public function parseUnscopedFields(?array $fields = null)
     {
         if ($fields === null) {
             return $this->createWithDefaultsIncluded();
@@ -65,4 +65,4 @@ class FieldsParser
     {
         return new FieldsConfig(true, array(), array());
     }
-} 
+}

--- a/src/Normalizer/ArrayNormalizer.php
+++ b/src/Normalizer/ArrayNormalizer.php
@@ -41,7 +41,7 @@ class ArrayNormalizer implements DenormalizerInterface, ContextAwareNormalizerIn
         return $result;
     }
 
-    public function mapFromEntity($entity, NormalizationContextInterface $context = null)
+    public function mapFromEntity($entity, ?NormalizationContextInterface $context = null)
     {
         $result = array();
         if ($entity !== null) {

--- a/src/Normalizer/ContextAwareDenormalizerInterface.php
+++ b/src/Normalizer/ContextAwareDenormalizerInterface.php
@@ -14,5 +14,5 @@ interface ContextAwareDenormalizerInterface extends DenormalizerInterface
      *
      * @return mixed
      */
-    public function mapToEntity($data, NormalizationContextInterface $context = null);
+    public function mapToEntity($data, ?NormalizationContextInterface $context = null);
 }

--- a/src/Normalizer/ContextAwareNormalizerInterface.php
+++ b/src/Normalizer/ContextAwareNormalizerInterface.php
@@ -9,11 +9,11 @@ interface ContextAwareNormalizerInterface extends NormalizerInterface
     /**
      * Maps some structure to raw data. Usually entity object to array
      *
-     * @param mixed                                                          $entity
-     * @param \Paysera\Component\Serializer\Entity\NormalizationContextInterface $context
+     * @param mixed $entity
+     * @param null|NormalizationContextInterface $context
      *
      * @return mixed
      */
-    public function mapFromEntity($entity, NormalizationContextInterface $context = null);
+    public function mapFromEntity($entity, ?NormalizationContextInterface $context = null);
 
 }

--- a/src/Normalizer/DistributedNormalizer.php
+++ b/src/Normalizer/DistributedNormalizer.php
@@ -127,12 +127,12 @@ class DistributedNormalizer implements DenormalizerInterface, ContextAwareNormal
     /**
      * Maps some structure to raw data. Usually entity object to array
      *
-     * @param mixed                                                          $entity
-     * @param \Paysera\Component\Serializer\Entity\NormalizationContextInterface $context
+     * @param mixed $entity
+     * @param null|NormalizationContextInterface $context
      *
      * @return mixed
      */
-    public function mapFromEntity($entity, NormalizationContextInterface $context = null)
+    public function mapFromEntity($entity, ?NormalizationContextInterface $context = null)
     {
         if ($this->normalizer instanceof ContextAwareNormalizerInterface) {
             $data = $this->normalizer->mapFromEntity($entity, $context);

--- a/src/Normalizer/ResultNormalizer.php
+++ b/src/Normalizer/ResultNormalizer.php
@@ -52,11 +52,11 @@ class ResultNormalizer implements ContextAwareNormalizerInterface, DenormalizerI
      * Maps some structure to raw data. Usually entity object to array
      *
      * @param mixed $entity
-     * @param \Paysera\Component\Serializer\Entity\NormalizationContextInterface $context
+     * @param null|NormalizationContextInterface $context
      *
      * @return mixed
      */
-    public function mapFromEntity($entity, NormalizationContextInterface $context = null)
+    public function mapFromEntity($entity, ?NormalizationContextInterface $context = null)
     {
         return array(
             $this->itemsKey => $this->mapItemsFromEntity(
@@ -128,7 +128,7 @@ class ResultNormalizer implements ContextAwareNormalizerInterface, DenormalizerI
         return $this->metadataNormalizer->mapFromEntity($result);
     }
 
-    protected function mapItemsFromEntity($items, NormalizationContextInterface $context = null)
+    protected function mapItemsFromEntity($items, ?NormalizationContextInterface $context = null)
     {
         return $this->itemsNormalizer->mapFromEntity($items, $context);
     }

--- a/src/Validation/PropertiesAwareValidator.php
+++ b/src/Validation/PropertiesAwareValidator.php
@@ -26,11 +26,11 @@ class PropertiesAwareValidator
 
     /**
      * @param ValidatorInterface $validator
-     * @param PropertyPathConverterInterface $propertyPathConverter
+     * @param null|PropertyPathConverterInterface $propertyPathConverter
      */
     public function __construct(
         $validator,
-        PropertyPathConverterInterface $propertyPathConverter = null
+        ?PropertyPathConverterInterface $propertyPathConverter = null
     ) {
         $this->validator = $validator;
         $this->propertyPathConverter = $propertyPathConverter;


### PR DESCRIPTION
To get rid of PHP 8.4 deprecations, the code was adjusted.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types