### PR TITLE
CORE-6223: Add permissionMatchMode property into src/Entity/Filter.php with getters and setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.1
+### Added
+- `permissionMatchMode` property into `src/Entity/Filter.php` with getters and setters
+
 ## 3.4.0
 ### Added
 - PHP 8.4 support, removed implicitly nullable parameter declarations.

--- a/src/Entity/Filter.php
+++ b/src/Entity/Filter.php
@@ -41,7 +41,7 @@ class Filter
     /**
      * @var string|null
      */
-    protected $permissionMatchMode;
+    protected $permissionMatchMode = null;
 
     /**
      * Sets orderBy

--- a/src/Entity/Filter.php
+++ b/src/Entity/Filter.php
@@ -39,6 +39,11 @@ class Filter
     protected $before;
 
     /**
+     * @var string|null
+     */
+    protected $permissionMatchMode;
+
+    /**
      * Sets orderBy
      *
      * @param string $orderBy
@@ -173,6 +178,26 @@ class Filter
     public function setBefore($before)
     {
         $this->before = $before;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPermissionMatchMode()
+    {
+        return $this->permissionMatchMode;
+    }
+
+    /**
+     * @param string|null $permissionMatchMode
+     *
+     * @return $this
+     */
+    public function setPermissionMatchMode($permissionMatchMode)
+    {
+        $this->permissionMatchMode = $permissionMatchMode;
+
         return $this;
     }
 


### PR DESCRIPTION
## CORE-6223 / CORE-6139                                                                                                                                                                                    
                                                                                                                                                                                                              
  ## Summary                                                                                                                                                                                                  
   
  Add `permissionMatchMode` property to the base `Filter` class to enable child filter classes (e.g., `AccountFilter` in downstream libraries) to support AND/OR permission matching logic.                   
                                                            
  **Changes:**                                                                                                                                                                                                
  - Added `protected $permissionMatchMode` property to `src/Entity/Filter.php`
  - Added `getPermissionMatchMode()` getter
  - Added `setPermissionMatchMode()` setter with fluent interface (returns `$this`)                                                                                                                           
  - Updated `CHANGELOG.md` with version 3.4.1 entry                                                                                                                                                           
                                                                                                                                                                                                              
  This is the **foundation layer** — the property lives in the base `Filter` class so all subclasses inherit it automatically without duplication.                                                            
                                                            
  ---                                                                                                                                                                                                         
                                                            
  ## What Changed

  ### `src/Entity/Filter.php`

  **Property (line 41):**

  ```php
  /**
   * @var string|null
   */
  protected $permissionMatchMode;                                                                                                                                                                             
                                                                                                                                                                                                              
  Getter (line 184):                                                                                                                                                                                          
                                                                                                                                                                                                              
  /**                                                       
   * @return string|null
   */
  public function getPermissionMatchMode()
  {
      return $this->permissionMatchMode;
  }

  Setter (line 189):                                                                                                                                                                                          
   
  /**                                                                                                                                                                                                         
   * @param string|null $permissionMatchMode                
   *
   * @return $this
   */
  public function setPermissionMatchMode($permissionMatchMode)
  {
      $this->permissionMatchMode = $permissionMatchMode;
                                                                                                                                                                                                              
      return $this;
  }                                                                                                                                                                                                           
                                                            
  Follows the same pattern as existing properties (orderBy, offset, limit, after, before) — nullable, fluent setter, simple getter.

  CHANGELOG.md

  Added version 3.4.1 entry documenting the new property.                                                                                                                                                     
   
  ---                                                                                                                                                                                                         
  Test Plan                                                 

  Prerequisites

  1. Download the test script: https://drive.google.com/file/d/1cS7H-quvRjHXS8rxwIEMOB6Ygz0etfMU/view?usp=sharing                                                                                             
  2. Place it in the project root: /path/to/lib-serializer/
                                                                                                                                                                                                              
  Run Tests                                                 

  cd /path/to/lib-serializer
  php test_permission_match_mode.php                                                                                                                                                                          
   
  Expected Output                                                                                                                                                                                             
                                                            
  ======================================================================
  lib-serializer: Filter::permissionMatchMode tests
  ======================================================================

  PASS: Default value is null (got: NULL)
  PASS: Set "and" (got: 'and')
  PASS: Set "or" (got: 'or')                                                                                                                                                                                  
  PASS: Reset to null (got: NULL)
  PASS: Setter returns $this (fluent) (got: true)                                                                                                                                                             
  PASS: Works with static create() (got: 'and')             
  PASS: Instances are independent (got: NULL)                                                                                                                                                                 
   
  ======================================================================                                                                                                                                      
  Results: 7 passed, 0 failed out of 7 tests                
  ======================================================================                                                                                                                                      
   
  Test Coverage (7 tests)                                                                                                                                                                                     
                                                            
  ┌───────────────────────┬──────────────────────────────────────────────────────────┐
  │         Case          │                       Verification                       │
  ├───────────────────────┼──────────────────────────────────────────────────────────┤                                                                                                                        
  │ Default value         │ getPermissionMatchMode() returns null on fresh instance  │
  ├───────────────────────┼──────────────────────────────────────────────────────────┤                                                                                                                        
  │ Set "and"             │ Getter returns 'and' after setPermissionMatchMode('and') │                                                                                                                        
  ├───────────────────────┼──────────────────────────────────────────────────────────┤
  │ Set "or"              │ Getter returns 'or' after setPermissionMatchMode('or')   │                                                                                                                        
  ├───────────────────────┼──────────────────────────────────────────────────────────┤                                                                                                                        
  │ Reset to null         │ Can set back to null                                     │
  ├───────────────────────┼──────────────────────────────────────────────────────────┤                                                                                                                        
  │ Fluent interface      │ Setter returns $this for method chaining                 │
  ├───────────────────────┼──────────────────────────────────────────────────────────┤
  │ Works with create()   │ Compatible with static factory method                    │
  ├───────────────────────┼──────────────────────────────────────────────────────────┤
  │ Instance independence │ Setting on one instance doesn't affect others            │
  └───────────────────────┴──────────────────────────────────────────────────────────┘                                                                                                                        
   
  The test script is standalone — no dependencies, no framework, no composer install needed. Just plain PHP.                                                                                                  
                                                            
  ---                                                                                                                                                                                                         
  Related                                                   
         
  - https://jira.paysera.net/browse/CORE-6223
  - https://jira.paysera.net/browse/CORE-6139                                                                                                                                                                 